### PR TITLE
feat: add string support on inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This package helps you render the forms via abi, and have input validations buil
 - `input-tag` Tab for type of that input's class
 - `input-error` Error mentioning class
 - `function-form-input` Input for the form class
+- `tooltip-input-final-value` The final value which will goto the contract call/invoke
+- `tooltip-input-text-hint` Hint tooltip value for input final value
 - `function-struct` Wrapper for a struct
 - `function-struct-header` Header with struct name inside the wrapper
 - `function-array-root` Main wrapper for an array type

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-tooltip": "^1.0.6",
     "@ryansonshine/commitizen": "4.2.8",
     "@ryansonshine/cz-conventional-changelog": "3.3.4",
     "@stitches/react": "^1.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ devDependencies:
   '@radix-ui/react-tabs':
     specifier: ^1.0.4
     version: 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-tooltip':
+    specifier: ^1.0.6
+    version: 1.0.6(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
   '@ryansonshine/commitizen':
     specifier: 4.2.8
     version: 4.2.8(@swc/core@1.3.78)
@@ -3830,6 +3833,41 @@ packages:
       '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-separator': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-toggle-group': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.19
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /@radix-ui/react-tooltip@1.0.6(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0):
+    resolution:
+      {
+        integrity: sha512-DmNFOiwEc2UDigsYj6clJENma58OelxD24O4IODoZ+3sQc3Zb+L8w1EP+y9laTuKCLAysPw4fD6/v0j4KNV8rg==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.11
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.19)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.19)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.19)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.19)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.19)(react@18.2.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.19
       '@types/react-dom': 18.2.7
       react: 18.2.0

--- a/src/ABIForm.tsx
+++ b/src/ABIForm.tsx
@@ -11,6 +11,7 @@ import {
 import FunctionForm from './FunctionForm';
 import { Content, List, Root, Trigger } from './UIComponents/Tabs/Tabs';
 import { ActiveTabClasses, DefaultTabClasses } from './utils/tailwindClasses';
+import { Provider } from './UIComponents/Tooltip/Tooltip';
 
 export type CallbackReturnType = {
   functionName: string;
@@ -77,55 +78,57 @@ export const ABIForm: React.FC<ABIFormProps> = ({
   const [activeTab, setActiveTab] = useState<'read' | 'write'>('write');
 
   return (
-    <Root value={activeTab} className="tab-root">
-      <List className="text-sm font-medium text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 tab-triggers-wrapper">
-        <Trigger
-          value="read"
-          className={`${
-            activeTab === 'read' ? ActiveTabClasses : DefaultTabClasses
-          } tab-trigger`}
-          onClick={() => {
-            setActiveTab('read');
-          }}
-        >
-          Read
-        </Trigger>
-        <Trigger
-          value="write"
-          className={`${
-            activeTab === 'write' ? ActiveTabClasses : DefaultTabClasses
-          } tab-trigger`}
-          onClick={() => {
-            setActiveTab('write');
-          }}
-        >
-          Write
-        </Trigger>
-      </List>
-      <Content value="read" className="tab-content">
-        {viewFunctions.map((viewFn) => (
-          <FunctionForm
-            key={`viewFn-${viewFn.name}`}
-            functionAbi={viewFn}
-            structs={structs}
-            callbackFn={callBackFn}
-            response={responses && responses[viewFn?.name]}
-            // enums={enums}
-          />
-        ))}
-      </Content>
-      <Content value="write" className="tab-content">
-        {externalFunctions.map((externalFn) => (
-          <FunctionForm
-            key={`externalFn-${externalFn.name}`}
-            functionAbi={externalFn}
-            structs={structs}
-            callbackFn={callBackFn}
-            response={responses && responses[externalFn?.name]}
-            // enums={enums}
-          />
-        ))}
-      </Content>
-    </Root>
+    <Provider>
+      <Root value={activeTab} className="tab-root">
+        <List className="text-sm font-medium text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 tab-triggers-wrapper">
+          <Trigger
+            value="read"
+            className={`${
+              activeTab === 'read' ? ActiveTabClasses : DefaultTabClasses
+            } tab-trigger`}
+            onClick={() => {
+              setActiveTab('read');
+            }}
+          >
+            Read
+          </Trigger>
+          <Trigger
+            value="write"
+            className={`${
+              activeTab === 'write' ? ActiveTabClasses : DefaultTabClasses
+            } tab-trigger`}
+            onClick={() => {
+              setActiveTab('write');
+            }}
+          >
+            Write
+          </Trigger>
+        </List>
+        <Content value="read" className="tab-content">
+          {viewFunctions.map((viewFn) => (
+            <FunctionForm
+              key={`viewFn-${viewFn.name}`}
+              functionAbi={viewFn}
+              structs={structs}
+              callbackFn={callBackFn}
+              response={responses && responses[viewFn?.name]}
+              // enums={enums}
+            />
+          ))}
+        </Content>
+        <Content value="write" className="tab-content">
+          {externalFunctions.map((externalFn) => (
+            <FunctionForm
+              key={`externalFn-${externalFn.name}`}
+              functionAbi={externalFn}
+              structs={structs}
+              callbackFn={callBackFn}
+              response={responses && responses[externalFn?.name]}
+              // enums={enums}
+            />
+          ))}
+        </Content>
+      </Root>
+    </Provider>
   );
 };

--- a/src/FunctionForm.tsx
+++ b/src/FunctionForm.tsx
@@ -22,12 +22,15 @@ import {
 import { Button, ButtonColorsClasses } from './UIComponents/Button/Button';
 import Tag, { TagColors } from './UIComponents/Tag/Tag';
 import {
+  finalizeValues,
   flattenArrays,
   flattenToRawCallData,
   transformStringArrayToInteger,
 } from './types/helper';
 import { CallbackReturnType } from './ABIForm';
 import { formsAtom } from './atoms';
+import { finalTransformedValue } from './types/dataTypes';
+import { Content, Portal, Root, Trigger } from './UIComponents/Tooltip/Tooltip';
 
 const typeToTagColor = (name: string): TagColors => {
   try {
@@ -147,6 +150,20 @@ const ParseInputFieldsFromObject: React.FC<IParseInputFieldsFromObject> = ({
               className="w-full bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 function-form-input"
               onChange={handleChange}
             />
+            <Root>
+              <Trigger>
+                <p className="tooltip-input-final-value">
+                  {finalTransformedValue(currentValueObject)}
+                </p>
+              </Trigger>
+              <Portal>
+                <Content>
+                  <p className="tooltip-input-text-hint">
+                    Finalized Value which will go for to contract
+                  </p>
+                </Content>
+              </Portal>
+            </Root>
             <p className="input-error">{error}</p>
           </div>
         );
@@ -426,14 +443,15 @@ const FunctionForm: React.FC<IFunctionForm> = ({
     validationSchema: Yup.object(validationSchema),
     onSubmit: (finalValues) => {
       try {
-        const rawArrayValues = flattenToRawCallData(finalValues);
+        const finalizedValues = finalizeValues(finalValues);
+        const rawArrayValues = flattenToRawCallData(finalizedValues);
         const starkliValues = transformStringArrayToInteger(
           flattenArrays(rawArrayValues) as string[]
         );
 
-        const starknetValues = Object.keys(finalValues).map(
+        const starknetValues = Object.keys(finalizedValues).map(
           // @ts-ignore
-          (key) => finalValues[key]
+          (key) => finalizedValues[key]
         );
 
         const callbackReturnValues: CallbackReturnType = {

--- a/src/UIComponents/Tooltip/Tooltip.tsx
+++ b/src/UIComponents/Tooltip/Tooltip.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+
+const { Root } = Tooltip;
+const { Provider } = Tooltip;
+const { Trigger } = Tooltip;
+const { Portal } = Tooltip;
+const Content: React.FC<Tooltip.TooltipContentProps> = (props) => (
+  <Tooltip.Content
+    className="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
+    {...props}
+  >
+    {props.children}
+  </Tooltip.Content>
+);
+
+export { Root, Provider, Trigger, Portal, Content };

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -21,8 +21,41 @@ export const isACoreType = (type: string): boolean => {
   return false;
 };
 
+function isStringButNotDecimalOrHex(value: string) {
+  // Check if the value is a string
+  if (typeof value === 'string') {
+    // Use a regular expression to check if it's not a decimal or hex
+    if (!/^(?!0x[\da-fA-F]+$)(?!\d+(\.\d+)?$)/.test(value)) {
+      return true; // It's a string, but not a decimal or hex
+    }
+  }
+  return false; // It's not a string, or it's a decimal or hex
+}
+
+function stringToUTF8Hex(inputString: string) {
+  // Return empty string in case no string is input to the function params
+  if (!inputString) return [];
+
+  const utf8Hex = [];
+
+  for (let i = 0; i < inputString.length; i++) {
+    const charCode = inputString.charCodeAt(i);
+    utf8Hex.push(charCode.toString(16));
+  }
+
+  return utf8Hex;
+}
+
+export function finalTransformedValue(value: string) {
+  if (!isStringButNotDecimalOrHex(value)) {
+    if (value.length === 0) return '';
+    return `0x${stringToUTF8Hex(value).join('')}`;
+  }
+  return value;
+}
+
 function validateCoreType(type: string, val: string): boolean {
-  const value = BigNumber(val);
+  const value = BigNumber(finalTransformedValue(val));
   switch (type) {
     case 'core::bool':
       return value.lte(1);

--- a/src/types/helper.ts
+++ b/src/types/helper.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { ABI, ABIFunction, ABIStruct, ABIEnum } from '.';
+import { finalTransformedValue } from './dataTypes';
 
 export function extractFunctionFromRawAbi(abi: ABI, functions: ABIFunction[]) {
   // Considering any here because it can be any of types.
@@ -119,6 +120,33 @@ export const transformStringArrayToInteger = (value: string[]): bigint[] =>
     }
     return lValue;
   });
+
+export function finalizeValues(value: any): any {
+  if (typeof value === 'string') {
+    return finalTransformedValue(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((val) => {
+      if (typeof val === 'string') {
+        return finalTransformedValue(val);
+      }
+      return finalizeValues(val);
+    });
+  }
+
+  if (typeof value === 'object') {
+    return Object.keys(value).reduce((prev, key) => {
+      const curr = value[key];
+      const currFVal = finalizeValues(curr);
+      return {
+        ...prev,
+        [key]: currFVal,
+      };
+    }, {});
+  }
+  return value;
+}
 
 export function flattenToRawCallData(value: any): any {
   if (typeof value === 'string') {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,22 @@ module.exports = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: 0 },
         },
+        slideDownAndFade: {
+          from: { opacity: 0, transform: 'translateY(-2px)' },
+          to: { opacity: 1, transform: 'translateY(0)' },
+        },
+        slideLeftAndFade: {
+          from: { opacity: 0, transform: 'translateX(2px)' },
+          to: { opacity: 1, transform: 'translateX(0)' },
+        },
+        slideUpAndFade: {
+          from: { opacity: 0, transform: 'translateY(2px)' },
+          to: { opacity: 1, transform: 'translateY(0)' },
+        },
+        slideRightAndFade: {
+          from: { opacity: 0, transform: 'translateX(-2px)' },
+          to: { opacity: 1, transform: 'translateX(0)' },
+        },
       },
       animation: {
         slideDown: 'slideDown 300ms cubic-bezier(0.87, 0, 0.13, 1)',


### PR DESCRIPTION
Add string inputs on the html inputs.
Show the actual value which will be sent on call/invoke 

Process of conversion 
- Convert string to the hex values, based on a regex check on string : ` /^(?!0x[\da-fA-F]+$)(?!\d+(\.\d+)?$)/`
  + 0x -> will consider as string and converted
  + 932 -> will not be considered as string, as deciaml
  + 0x324ad will be considered as hex
  + 0x3234skld will be considered as string.
  
 Final Conversions will be done in the onSubmit method before calling the callback function in component.